### PR TITLE
Using ScriptsToProcess instead of RequiredModules in manifest.  Impor…

### DIFF
--- a/Modules/Office365DSC/Office365DSC.psd1
+++ b/Modules/Office365DSC/Office365DSC.psd1
@@ -51,17 +51,17 @@ PowerShellVersion = '5.1'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName = "ReverseDSC"; ModuleVersion = "1.9.3.0"; },
-                    @{ModuleName = "MSOnline"; ModuleVersion = "1.1.183.17"; },
-                    @{ModuleName = "Microsoft.Online.SharePoint.PowerShell"; ModuleVersion = "16.0.8316.0"; },
-                    @{ModuleName = "SharePointPnPPowerShellOnline"; ModuleVersion = "3.5.1901.0"; },
-                    @{ModuleName = "MicrosoftTeams"; ModuleVersion = "0.9.6"; })
+# RequiredModules = @(@{ModuleName = "ReverseDSC"; ModuleVersion = "1.9.3.0"; },
+#                     @{ModuleName = "MSOnline"; ModuleVersion = "1.1.183.17"; },
+#                     @{ModuleName = "Microsoft.Online.SharePoint.PowerShell"; ModuleVersion = "16.0.8316.0"; },
+#                     @{ModuleName = "SharePointPnPPowerShellOnline"; ModuleVersion = "3.5.1901.0"; },
+#                     @{ModuleName = "MicrosoftTeams"; ModuleVersion = "0.9.6"; })
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()
 
 # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-# ScriptsToProcess = @()
+  ScriptsToProcess = @('Office365DSCRequiredModules.ps1')
 
 # Type files (.ps1xml) to be loaded when importing this module
 # TypesToProcess = @()

--- a/Modules/Office365DSC/Office365DSCRequiredModules.ps1
+++ b/Modules/Office365DSC/Office365DSCRequiredModules.ps1
@@ -1,0 +1,5 @@
+Import-Module -Name 'Microsoft.Online.SharePoint.PowerShell' -Version '16.0.8316.0' -Force -Verbose:$false -Global
+Import-Module -Name 'MicrosoftTeams' -Version '0.9.6' -Force -Verbose:$false -Global
+Import-Module -Name 'MSOnline' -Version '1.1.183.17' -Force -Verbose:$false -Global
+Import-Module -Name 'ReverseDSC' -Version '1.9.3.0' -Force -Verbose:$false -Global
+Import-Module -Name 'SharePointPnPPowerShellOnline' -Version '3.5.1901.0' -Force -Verbose:$false -Global


### PR DESCRIPTION
#### Pull Request (PR) description
Imports required modules via **ScriptsToProcess** instead of **RequiredModules**.
This was done so that Verbose output could be suppressed during module import, which greatly reduces the noise seen during DSC LCM runs using the **-Verbose** switch.

#### This Pull Request (PR) fixes the following issues
None