### PR TITLE
Fixed abstraction for atp365

### DIFF
--- a/Modules/Office365DSC/Modules/O365DSCReverse.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverse.psm1
@@ -116,9 +116,15 @@ function Start-O365ConfigurationExtract
                 $ATPPolicies = Get-AtpPolicyForO365
                 foreach ($atpPolicy in $ATPPolicies)
                 {
-                    $DSCContent += Export-TargetResource -IsSingleInstance "Yes" `
-                                                         -GlobalAdminAccount $GlobalAdminAccount `
-                                                         -Identity $atpPolicy.Identity
+                    $partialContent = Export-TargetResource -IsSingleInstance "Yes" `
+                                                            -GlobalAdminAccount $GlobalAdminAccount `
+                                                            -Identity $atpPolicy.Identity
+
+                    if ($partialContent.ToLower().IndexOf($organization.ToLower()) -gt 0)
+                    {
+                        $partialContent = $partialContent -ireplace [regex]::Escape($organization), "`$(`$ConfigurationData.NonNodeData.OrganizationName)"
+                    }
+                    $DSCContent += $partialContent
                 }
             }
             else


### PR DESCRIPTION
Fixed an issue where the ATP for O365 was not properly abstracting the current source tenant's name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/184)
<!-- Reviewable:end -->
