### PR TITLE
Fixed ReverseDSC for EXOClientAccessRule

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
@@ -95,31 +95,24 @@ function Get-TargetResource
     else
     {
         $result = @{
-            Ensure = 'Present'
+            Identity                             = $Identity
+            Action                               = $ClientAccessRule.Action
+            AnyOfAuthenticationTypes             = $ClientAccessRule.AnyOfAuthenticationTypes
+            AnyOfClientIPAddressesOrRanges       = $ClientAccessRule.AnyOfClientIPAddressesOrRanges
+            AnyOfProtocols                       = $ClientAccessRule.AnyOfProtocols
+            Enabled                              = $ClientAccessRule.Enabled
+            ExceptAnyOfAuthenticationTypes       = $ClientAccessRule.ExceptAnyOfAuthenticationTypes
+            ExceptAnyOfClientIPAddressesOrRanges = $ClientAccessRule.ExceptAnyOfClientIPAddressesOrRanges
+            ExceptAnyOfProtocols                 = $ClientAccessRule.ExceptAnyOfProtocols
+            ExceptUsernameMatchesAnyOfPatterns   = $ClientAccessRule.ExceptUsernameMatchesAnyOfPatterns
+            Priority                             = $ClientAccessRule.Priority
+            RuleScope                            = $ClientAccessRule.RuleScope
+            UserRecipientFilter                  = $ClientAccessRule.UserRecipientFilter
+            UsernameMatchesAnyOfPatterns         = $ClientAccessRule.UsernameMatchesAnyOfPatterns
+            Ensure                               = 'Present'
+            GlobalAdminAccount                   = $GlobalAdminAccount
         }
 
-        $PSBoundParameters += @{
-            Scope = $RuleScope
-        }
-
-        foreach ($KeyName in ($PSBoundParameters.Keys | Where-Object -FilterScript { $_ -ne 'Ensure' }))
-        {
-            if ($null -ne $ClientAccessRule.$KeyName)
-            {
-                $result += @{
-                    $KeyName = $ClientAccessRule.$KeyName
-                }
-            }
-            else
-            {
-                $result += @{
-                    $KeyName = $PSBoundParameters[$KeyName]
-                }
-            }
-
-        }
-
-        $result.Remove('Scope') | Out-Null
         Write-Verbose -Message "Found ClientAccessRule $($Identity)"
         Write-Verbose -Message "Get-TargetResource Result: `n $(Convert-O365DscHashtableToString -Hashtable $result)"
         return $result

--- a/Modules/Office365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOClientAccessRule/MSFT_EXOClientAccessRule.psm1
@@ -106,11 +106,15 @@ function Get-TargetResource
             ExceptAnyOfProtocols                 = $ClientAccessRule.ExceptAnyOfProtocols
             ExceptUsernameMatchesAnyOfPatterns   = $ClientAccessRule.ExceptUsernameMatchesAnyOfPatterns
             Priority                             = $ClientAccessRule.Priority
-            RuleScope                            = $ClientAccessRule.RuleScope
             UserRecipientFilter                  = $ClientAccessRule.UserRecipientFilter
             UsernameMatchesAnyOfPatterns         = $ClientAccessRule.UsernameMatchesAnyOfPatterns
             Ensure                               = 'Present'
             GlobalAdminAccount                   = $GlobalAdminAccount
+        }
+
+        if (-not [System.String]::IsNullOrEmpty($ClientAccessRule.RuleScope))
+        {
+            $result.Add("RuleScope", $ClientAccessRule.RuleScope)
         }
 
         Write-Verbose -Message "Found ClientAccessRule $($Identity)"


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue where only key properties where being extracted from the Get-TargetResource function in EXOClientAccessRule.

#### This Pull Request (PR) fixes the following issues
ReverseDSC from EXOCLientAccessRule

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/217)
<!-- Reviewable:end -->
