### PR TITLE
fixes for some multiple resources related to compliance

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAcceptedDomain/MSFT_EXOAcceptedDomain.psm1
@@ -222,18 +222,13 @@ function Export-TargetResource
     Test-MSCloudLogin -O365Credential $GlobalAdminAccount `
                       -Platform ExchangeOnline
 
-    $AllAcceptedDomains = Get-AcceptedDomain
+    [array]$AllAcceptedDomains = Get-AcceptedDomain
 
     $dscContent = ""
-    $i = 0
-    $totalCount = $AllAcceptedDomains.Count
-    if ($null = $totalCount)
-    {
-        $totalCount = 1
-    }
+    $i = 1
     foreach ($domain in $AllAcceptedDomains)
     {
-        Write-Information "    [$i/$totalCount] $($domain.Identity)"
+        Write-Information "    [$i/$($AllAcceptedDomains.Count)] $($domain.Identity)"
 
         $Params = @{
             Identity           = $domain.Identity
@@ -247,6 +242,7 @@ function Export-TargetResource
         $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
         $content += "        }`r`n"
         $dscContent += $content
+        $i++
     }
     return $dscContent
 }

--- a/Modules/Office365DSC/DSCResources/MSFT_SCCaseHoldPolicy/MSFT_SCCaseHoldPolicy.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCCaseHoldPolicy/MSFT_SCCaseHoldPolicy.psm1
@@ -296,12 +296,14 @@ function Export-TargetResource
     Test-MSCloudLogin -O365Credential $GlobalAdminAccount `
                       -Platform SecurityComplianceCenter
 
-    $cases = Get-ComplianceCase
+    [array]$cases = Get-ComplianceCase
+
+    $dscContent = ""
     $i = 1
     foreach ($case in $cases)
     {
-        Write-Information "    [$i/$($cases.Count)] Scanning Policies in Case {$($case.Name)}"
-        $policies = Get-CaseHoldPolicy -Case $case.Name
+        Write-Information "    [$i/$($Cases.Count)] Scanning Policies in Case {$($case.Name)}"
+        [array]$policies = Get-CaseHoldPolicy -Case $case.Name
 
         $j = 1
         foreach($policy in $policies)
@@ -314,17 +316,18 @@ function Export-TargetResource
             }
             $result = Get-TargetResource @params
             $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
-            $content = "        SCCaseHoldPolicy " + (New-GUID).ToString() + "`r`n"
-            $content += "        {`r`n"
+            $partialContent = "        SCCaseHoldPolicy " + (New-GUID).ToString() + "`r`n"
+            $partialContent += "        {`r`n"
             $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
-            $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
-            $content += "        }`r`n"
+            $partialContent += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
+            $partialContent += "        }`r`n"
+            $dscContent += $partialContent
             $j++
         }
         $i++
     }
 
-    return $content
+    return $dscContent
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/Modules/Office365DSC/DSCResources/MSFT_SCComplianceCase/MSFT_SCComplianceCase.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCComplianceCase/MSFT_SCComplianceCase.psm1
@@ -202,26 +202,28 @@ function Export-TargetResource
     $InformationPreference = "Continue"
     Test-MSCloudLogin -O365Credential $GlobalAdminAccount `
                       -Platform SecurityComplianceCenter
-    $Cases = Get-ComplianceCase
+    [array]$Cases = Get-ComplianceCase
 
+    $dscContent = ""
     $i = 1
     foreach ($Case in $Cases)
     {
-        Write-Information "    - [$i/$($Cases.Length)] $($Case.Name)"
+        Write-Information "    - [$i/$($Cases.Count)] $($Case.Name)"
         $params = @{
             Name               = $Case.Name
             GlobalAdminAccount = $GlobalAdminAccount
         }
         $result = Get-TargetResource @params
         $result.GlobalAdminAccount = Resolve-Credentials -UserName "globaladmin"
-        $content = "        SCComplianceCase " + (New-GUID).ToString() + "`r`n"
-        $content += "        {`r`n"
+        $partialContent = "        SCComplianceCase " + (New-GUID).ToString() + "`r`n"
+        $partialContent += "        {`r`n"
         $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
-        $content += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
-        $content += "        }`r`n"
+        $partialContent += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName "GlobalAdminAccount"
+        $partialContent += "        }`r`n"
+        $dscContent += $partialContent
         $i++
     }
-    return $content
+    return $dscContent
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/Tests/Unit/Office365DSC/Office365DSC.EXOAcceptedDomain.Tests.ps1
+++ b/Tests/Unit/Office365DSC/Office365DSC.EXOAcceptedDomain.Tests.ps1
@@ -202,8 +202,38 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 GlobalAdminAccount = $GlobalAdminAccount
             }
 
-            It "Should Reverse Engineer resource from the Export method" {
-                Export-TargetResource @testParams
+            $acceptedDomain1 = @{
+                DomainType         = 'Authoritative'
+                Identity           = 'different1.tailspin.com'
+                MatchSubDomains    = $false
+                OutboundOnly       = $false
+            }
+
+            $acceptedDomain2 = @{
+                DomainType         = 'Authoritative'
+                Identity           = 'different2.tailspin.com'
+                MatchSubDomains    = $false
+                OutboundOnly       = $false
+            }
+
+            It "Should Reverse Engineer resource from the Export method when single" {
+                Mock -CommandName Get-AcceptedDomain -MockWith {
+                    return $acceptedDomain1
+                }
+
+                $exported = Export-TargetResource @testParams
+                ([regex]::Matches($exported, " EXOAcceptedDomain " )).Count | Should Be 1
+                $exported.Contains("different1.tailspin.com") | Should Be $true
+            }
+
+            It "Should Reverse Engineer resource from the Export method when multiple" {
+                Mock -CommandName Get-AcceptedDomain -MockWith {
+                    return @($acceptedDomain1, $acceptedDomain2)
+                }
+
+                $exported = Export-TargetResource @testParams
+                ([regex]::Matches($exported, " EXOAcceptedDomain " )).Count | Should Be 2
+                $exported.Contains("different2.tailspin.com") | Should Be $true
             }
         }
     }

--- a/Tests/Unit/Office365DSC/Office365DSC.SCCaseHoldRule.Tests.ps1
+++ b/Tests/Unit/Office365DSC/Office365DSC.SCCaseHoldRule.Tests.ps1
@@ -166,14 +166,20 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 GlobalAdminAccount = $GlobalAdminAccount
             }
 
-            Mock -CommandName Get-CaseHoldRule -MockWith {
-                return @{
-                    Name               = "TestRule"
-                    Policy             = "12345-12345-12345-12345-12345"
-                    Comment            = "Different comment"
-                    Disabled           = $true
-                    ContentMatchQuery  = "filename:2016 budget filetype:xlsx"
-                }
+            $testRule1 = @{
+                Name               = "TestRule1"
+                Policy             = "12345-12345-12345-12345-12345"
+                Comment            = "Different comment"
+                Disabled           = $true
+                ContentMatchQuery  = "filename:2016 budget filetype:xlsx"
+            }
+
+            $testRule2 = @{
+                Name               = "TestRule2"
+                Policy             = "12345-12345-12345-12345-12345"
+                Comment            = "Different comment"
+                Disabled           = $true
+                ContentMatchQuery  = "filename:2016 budget filetype:xlsx"
             }
 
             Mock -CommandName Get-CaseHoldPolicy -MockWith {
@@ -183,8 +189,25 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 }
             }
 
-            It "Should Reverse Engineer resource from the Export method" {
-                Export-TargetResource @testParams
+            It "Should Reverse Engineer resource from the Export method when single" {
+                Mock -CommandName Get-CaseHoldRule -MockWith {
+                    return $testRule1
+                }
+
+                $exported = Export-TargetResource @testParams
+                ([regex]::Matches($exported, " SCCaseHoldRule " )).Count | Should Be 1
+                $exported.Contains("TestRule1") | Should Be $true
+            }
+
+            It "Should Reverse Engineer resource from the Export method when multiple" {
+                Mock -CommandName Get-CaseHoldRule -MockWith {
+                    return @($testRule1, $testRule2)
+                }
+
+                $exported = Export-TargetResource @testParams
+                ([regex]::Matches($exported, " SCCaseHoldRule " )).Count | Should Be 2
+                $exported.Contains("TestRule1") | Should Be $true
+                $exported.Contains("TestRule2") | Should Be $true
             }
         }
     }

--- a/Tests/Unit/Office365DSC/Office365DSC.SCComplianceCase.Tests.ps1
+++ b/Tests/Unit/Office365DSC/Office365DSC.SCComplianceCase.Tests.ps1
@@ -198,16 +198,45 @@ Describe -Name $Global:DscHelper.DescribeHeader -Fixture {
                 GlobalAdminAccount = $GlobalAdminAccount
             }
 
-            Mock -CommandName Get-ComplianceCase -MockWith {
-                return @{
-                    Name        = "TestCase"
-                    Status      = "Active"
-                    Description = "This is a test Case"
-                }
+            $testCase1 = @{
+                Name        = "TestCase1"
+                Status      = "Active"
+                Description = "This is a test Case (1)"
             }
 
-            It "Should Reverse Engineer resource from the Export method" {
-                Export-TargetResource @testParams
+            $testCase2 = @{
+                Name        = "TestCase2"
+                Status      = "Active"
+                Description = "This is a test Case (2)"
+            }
+
+            Mock -CommandName Get-ComplianceCase -ParameterFilter { $Name -eq "TestCase1" }  -MockWith {
+                return $testCase1
+            }
+
+            Mock -CommandName Get-ComplianceCase -ParameterFilter { $Name -eq "TestCase2" } -MockWith {
+                return $testCase2
+            }
+
+            It "Should Reverse Engineer resource from the Export method when single result" {
+                Mock -CommandName Get-ComplianceCase -MockWith {
+                    return $testCase1
+                }
+
+                $exported = Export-TargetResource @testParams
+                ([regex]::Matches($exported, " SCComplianceCase " )).Count | Should Be 1
+                $exported.Contains("TestCase1") | Should Be $true
+            }
+
+            It "Should Reverse Engineer resource from the Export method when multiple results" {
+                Mock -CommandName Get-ComplianceCase -MockWith {
+                    return @($testCase1, $testCase2)
+                }
+
+                $exported = Export-TargetResource @testParams
+                ([regex]::Matches($exported, " SCComplianceCase " )).Count | Should Be 2
+                $exported.Contains("TestCase1") | Should Be $true
+                $exported.Contains("TestCase2") | Should Be $true
             }
         }
     }


### PR DESCRIPTION
Pull Request (PR) description
This PR resolves some issues with extracting information about multiple Compliance cases. Only one case hold policy and one case hold rule would be shown.
I also modified the code to extract accepted domains a bit.
The fix is mostly concatenating string differently and forcing the results of Get-* command to arrays to that it behaves as expected.

This Pull Request (PR) fixes the following issues
None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/259)
<!-- Reviewable:end -->
