### PR TITLE
SCComplianceSearch: fixed missing case name

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_SCComplianceSearch/MSFT_SCComplianceSearch.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SCComplianceSearch/MSFT_SCComplianceSearch.psm1
@@ -368,7 +368,7 @@ function Export-TargetResource
         {
             $params = @{
                 Name               = $search.Name
-                Case               = $search.Case
+                Case               = $case.Name
                 GlobalAdminAccount = $GlobalAdminAccount
             }
             Write-Information "        - [$i/$($searches.Name.Count)] $($search.Name)"


### PR DESCRIPTION
#### Pull Request (PR) description
Nothing special. $search.Case property does not exist so the case name of the search was empty when the resource was exported. $Search.CaseName does exist but it was empty on my test environment so I just took the case that was currently evaluated to be safe.

#### This Pull Request (PR) fixes the following issues
Fixes #262

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/263)
<!-- Reviewable:end -->
