### PR TITLE
BREAKING CHANGE: The output directory is no longer opened up when quiet parameter used

### DIFF
--- a/Modules/Office365DSC/Modules/O365DSCReverse.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverse.psm1
@@ -3,6 +3,10 @@ function Start-O365ConfigurationExtract
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param(
+        [Parameter()]
+        [Switch]
+        $Quiet,
+
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]
         $GlobalAdminAccount,
@@ -1969,9 +1973,11 @@ function Start-O365ConfigurationExtract
     $DSCContent += "$ConfigName -ConfigurationData .\ConfigurationData.psd1 -GlobalAdminAccount `$GlobalAdminAccount"
     #endregion
 
+    $shouldOpenOutputDirectory = !$Quiet
     #region Prompt the user for a location to save the extract and generate the files
     if ($null -eq $Path -or "" -eq $Path)
     {
+        $shouldOpenOutputDirectory = $true
         $OutputDSCPath = Read-Host "Destination Path"
     }
     else
@@ -2028,5 +2034,9 @@ function Start-O365ConfigurationExtract
         $outputConfigurationData = $OutputDSCPath + "ConfigurationData.psd1"
         New-ConfigurationDataDocument -Path $outputConfigurationData
     }
-    Invoke-Item -Path $OutputDSCPath
+
+    if ($shouldOpenOutputDirectory)
+    {
+        Invoke-Item -Path $OutputDSCPath
+    }
 }

--- a/Modules/Office365DSC/Modules/O365DSCReverse.psm1
+++ b/Modules/Office365DSC/Modules/O365DSCReverse.psm1
@@ -1975,7 +1975,7 @@ function Start-O365ConfigurationExtract
 
     $shouldOpenOutputDirectory = !$Quiet
     #region Prompt the user for a location to save the extract and generate the files
-    if ($null -eq $Path -or "" -eq $Path)
+    if ([System.String]::IsNullOrEmpty($Path))
     {
         $shouldOpenOutputDirectory = $true
         $OutputDSCPath = Read-Host "Destination Path"

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -1701,21 +1701,24 @@ function Export-O365Configuration
             Start-O365ConfigurationExtract -GlobalAdminAccount $GlobalAdminAccount `
                                            -Workloads $Workloads `
                                            -Path $Path -FileName $FileName `
-                                           -MaxProcesses $MaxProcesses
+                                           -MaxProcesses $MaxProcesses `
+                                           -Quiet
         }
         elseif ($null -ne $ComponentsToExtract)
         {
             Start-O365ConfigurationExtract -GlobalAdminAccount $GlobalAdminAccount `
                                            -ComponentsToExtract $ComponentsToExtract `
                                            -Path $Path -FileName $FileName `
-                                           -MaxProcesses $MaxProcesses
+                                           -MaxProcesses $MaxProcesses `
+                                           -Quiet
         }
         else
         {
             Start-O365ConfigurationExtract -GlobalAdminAccount $GlobalAdminAccount `
                                            -AllComponents `
                                            -Path $Path -FileName $FileName `
-                                           -MaxProcesses $MaxProcesses
+                                           -MaxProcesses $MaxProcesses `
+                                           -Quiet
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
The output directory is no longer opened up when the quiet switch is used. This is the expected behavior when calling Export-O365Configuration from other scripts with the Quit switch and Path parameter provided.

Not sure how to test this, so no tests provided. Open to ideas.

#### This Pull Request (PR) fixes the following issues
- Fixes #265

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/267)
<!-- Reviewable:end -->
