### PR TITLE
Cleaning Information Channel in ReverseDSC scenario

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOPropertyBag/MSFT_SPOPropertyBag.psm1
@@ -304,6 +304,7 @@ function Export-TargetResource
     $elapsedTime = 0
     do
     {
+        $InformationPreference = 'SilentlyContinue'
         $jobs = Get-Job | Where-Object -FilterScript { $_.Name -like '*SPOPropertyBag*' }
         $count = $jobs.Length
         foreach ($job in $jobs)

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
@@ -283,6 +283,7 @@ function Export-TargetResource
     $elapsedTime = 0
     do
     {
+        $InformationPreference = 'SilentlyContinue'
         $jobs = Get-Job | Where-Object -FilterScript { $_.Name -like '*SPOUserProfileProperty*' }
         $count = $jobs.Length
         foreach ($job in $jobs)

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsUser/MSFT_TeamsUser.psm1
@@ -351,6 +351,7 @@ function Export-TargetResource
     $elapsedTime = 0
     do
     {
+        $InformationPreference = 'SilentlyContinue'
         $jobs = Get-Job | Where-Object -FilterScript { $_.Name -like '*TeamsUser*' }
         $count = $jobs.Length
         foreach ($job in $jobs)


### PR DESCRIPTION
#### Pull Request (PR) description
Extracting resources that use parallel jobs prints out "Loaded Module Microsoft.Teams.config" messages for each instance. This hides these messages.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/342)
<!-- Reviewable:end -->
