### PR TITLE
O365User: fixed a bug where only the last user was extracted

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
@@ -564,7 +564,6 @@ function Export-TargetResource
             }
 
             $result = Get-TargetResource @params
-            $content = ""
             if ($null -ne $result.UserPrincipalName)
             {
                 $result.Password = Resolve-Credentials -UserName "globaladmin"


### PR DESCRIPTION

#### Pull Request (PR) description
The variable that represented all of the users was being reset to an empty string. This resulted in only the last user from the tenant being extracted.

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/348)
<!-- Reviewable:end -->
