### PR TITLE
EXOAtpPolicyForO365: properties were duplicated

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_EXOAtpPolicyForO365/MSFT_EXOAtpPolicyForO365.psm1
@@ -275,7 +275,7 @@ function Export-TargetResource
                 $content += "        EXOAtpPolicyForO365 " + (New-GUID).ToString() + "`r`n"
                 $content += "        {`r`n"
                 $currentDSCBlock = Get-DSCBlock -Params $result -ModulePath $PSScriptRoot
-                $currentDSCBlock += Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'GlobalAdminAccount'
+                $currentDSCBlock = Convert-DSCStringParamToVariable -DSCBlock $currentDSCBlock -ParameterName 'GlobalAdminAccount'
                 if ($currentDSCBlock.ToLower().IndexOf($organization.ToLower()) -gt 0)
                 {
                     $currentDSCBlock = $currentDSCBlock -ireplace [regex]::Escape($organization), "`$OrganizationName"


### PR DESCRIPTION

#### Pull Request (PR) description
The properties for EXOAtpPolicyForO365 were duplicated in the generated ps1 document.
As such it could not be compiled into a .mof file.

```powershell
  Node localhost
    {
        EXOAtpPolicyForO365 0dd29c24-89d3-4282-a3af-12bca9337cb9
        {
            AllowClickThrough         = $False;
            BlockUrls                 = @("docs.microsoft.com","www.microsoft.com");
            EnableATPForSPOTeamsODB   = $False;
            EnableSafeLinksForClients = $False;
            Ensure                    = "Present";
            GlobalAdminAccount        = "$Credsglobaladmin";
            Identity                  = "Default";
            IsSingleInstance          = "Yes";
            TrackClicks               = $False;
            AllowClickThrough         = $False;
            BlockUrls                 = @("docs.microsoft.com","www.microsoft.com");
            EnableATPForSPOTeamsODB   = $False;
            EnableSafeLinksForClients = $False;
            Ensure                    = "Present";
            GlobalAdminAccount        = $Credsglobaladmin;
            Identity                  = "Default";
            IsSingleInstance          = "Yes";
            TrackClicks               = $False;
        }
    }
```

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/350)
<!-- Reviewable:end -->
