### PR TITLE
SPOUserProfileProperty: fixed util module import

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOUserProfileProperty/MSFT_SPOUserProfileProperty.psm1
@@ -229,7 +229,7 @@ function Export-TargetResource
 
             # Implicitly load the Office365DSCUtil.psm1 module in order to be able to call
             # into the Invoke-O36DSCCommand cmdlet;
-            Import-Module ($ScriptRoot + "\MSFT_SPOUserProfileProperty.psm1") -Force | Out-Null
+            Import-Module ($ScriptRoot + "\..\..\Modules\Office365DSCUtil.psm1") -Force | Out-Null
 
             # Invoke the logic that extracts the all the Property Bag values of the current site using the
             # the invokation wrapper that handles throttling;


### PR DESCRIPTION
#### Pull Request (PR) description
This PR solves a problem with the extraction of the SPOUserProfileProperty resource. The Invoke-O365DSCCommand was not available because the Office365DSCUtil module was incorrectly imported.

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/351)
<!-- Reviewable:end -->
