### PR TITLE
MSFT_TeamsTeam: Removed Ensure parameter defaults in function Test-TargetResource

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -481,7 +481,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateSet("Present", "Absent")]
         [System.String]
-        $Ensure = "Present",
+        $Ensure,
 
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]


### PR DESCRIPTION

#### Pull Request (PR) description
The default setting to Ensure = "Present" in function "Test-TargetResource" will always  [Skip Set] if the Ensure parameter is not set.
Due to the default setting "Present", the variable $testResult in function "Test-TargetResource" will return to $true, even if the Team is not yet created (Ensure="Absent").

> VERBOSE: [RVRAZRO365Dsc1]: [[TeamsTeam]TeamsTeam_MySecondTeam] Test-TargetResource returned True
> VERBOSE: [RVRAZRO365Dsc1]: LCM: [ End Test ] [[TeamsTeam]TeamsTeam_MySecondTeam] in 2.0890 seconds.
> VERBOSE: [RVRAZRO365Dsc1]: LCM: **[ Skip Set ]** [[TeamsTeam]TeamsTeam_MySecondTeam]

#### This Pull Request (PR) fixes the following issues
fixes issue #372  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/373)
<!-- Reviewable:end -->
