### PR TITLE
MSFT_TeamsTeam: Fixed minor typos

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/readme.md
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/readme.md
@@ -2,13 +2,13 @@
 
 ## Description
 
-This resource configugures or creates a new Team.
+This resource configures or creates a new Team.
 
 ## Parameters
 
 Ensure
 
-- Required: No (Defaults to 'Present')
+- Required: No (defaults to 'Present')
 - Description: `Present` is the only value accepted.
   Configurations using `Ensure = 'Absent'` will throw an Error!
 
@@ -137,16 +137,16 @@ Owner
 Visibility
 
 - Required: No
-- Description: Set to Public to allow all users in your organization to
-  join the group by default. Set to Private to require that an owner
-  approve the join request.
+- Description: Set to "Public" to allow all users in your organization to
+  join the group by default. Set to "Private" to require that an owner
+  approves the join request.
 
 GroupId
 
 - Required: No
 - Description: There can be duplicate DisplayName for Teams so if
   if duplicate Teams exist you can pass in GroupID to filter and
-  retreive unique team.
+  retrieve unique team.
 
 GlobalAdminAccount
 
@@ -178,6 +178,6 @@ GlobalAdminAccount
             AllowCustomMemes                  = $True
             AllowGuestCreateUpdateChannels    = $false
             AllowGuestDeleteChannels          = $false
-            GlobalAdminAccount                =  $GlobalAdminAccount
+            GlobalAdminAccount                = $GlobalAdminAccount
         }
 ```


### PR DESCRIPTION
I fixed minor typos.

#### Pull Request (PR) description
I fixed minor typos in the readme.md file

#### This Pull Request (PR) fixes the following issues
It relates to issue #371 and #372. Please decide whether I should modify the description of [`Ensure` parameter](https://github.com/microsoft/Office365DSC/blob/Dev/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/readme.md#parameters) as follows as well:

Ensure

- Required: No (Defaults to 'Present')
- Description: `Present` is the only value accepted.
  ~~Configurations using `Ensure = 'Absent'` will throw an Error!~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/374)
<!-- Reviewable:end -->
