### PR TITLE
TeamsTeam: Added Ensure param to PSBoundParameters

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -494,7 +494,8 @@ function Test-TargetResource
 
     Write-Verbose -Message "Current Values: $(Convert-O365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-O365DscHashtableToString -Hashtable $PSBoundParameters)"
-
+    
+    $PSBoundParameters.Add('Ensure',$Ensure)
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
     $ValuesToCheck.Remove('GroupID') | Out-Null

--- a/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_TeamsTeam/MSFT_TeamsTeam.psm1
@@ -495,7 +495,9 @@ function Test-TargetResource
     Write-Verbose -Message "Current Values: $(Convert-O365DscHashtableToString -Hashtable $CurrentValues)"
     Write-Verbose -Message "Target Values: $(Convert-O365DscHashtableToString -Hashtable $PSBoundParameters)"
     
-    $PSBoundParameters.Add('Ensure',$Ensure)
+    If (!$PSBoundParameters.ContainsKey('Ensure')) {
+        $PSBoundParameters.Add('Ensure',$Ensure)
+    }
     $ValuesToCheck = $PSBoundParameters
     $ValuesToCheck.Remove('GlobalAdminAccount') | Out-Null
     $ValuesToCheck.Remove('GroupID') | Out-Null


### PR DESCRIPTION
#### Pull Request (PR) description
If the `Ensure` parameter is not set explicitly by the caller, the `Ensure` parameter was not added to the $PSBoundParameters because default values are not added to the `$PSBoundParameters` and thereby wasn't a key to check on in the `$ValuesToCheck.Keys` in the Tes-TargetResource function.

#### This Pull Request (PR) fixes the following issues
- Fixes #372

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/385)
<!-- Reviewable:end -->
