### PR TITLE
Allow extraction of SPOSite without owners

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
@@ -184,6 +184,11 @@ function Get-TargetResource
             $DenyAddAndCustomizePagesValue = $false
         }
 
+        $siteOwnerEmail = $site.OwnerEmail
+        if ([System.String]::IsNullOrEmpty($siteOwnerEmail))
+        {
+            $siteOwnerEmail = $GlobalAdminAccount.UserName
+        }
         return @{
             Url                                         = $Url
             Title                                       = $site.Title
@@ -197,7 +202,7 @@ function Get-TargetResource
             StorageMaximumLevel                         = $site.StorageMaximumLevel
             StorageWarningLevel                         = $site.StorageWarningLevel
             AllowSelfServiceUpgrade                     = $site.AllowSelfServiceUpgrade
-            Owner                                       = $site.OwnerEmail
+            Owner                                       = $siteOwnerEmail
             CommentsOnSitePagesDisabled                 = $site.CommentsOnSitePagesDisabled
             DefaultLinkPermission                       = $site.DefaultLinkPermission
             DefaultSharingLinkType                      = $site.DefaultSharingLinkType

--- a/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_SPOSite/MSFT_SPOSite.psm1
@@ -719,7 +719,7 @@ function Export-TargetResource
             GlobalAdminAccount = $GlobalAdminAccount
             Url                = $site.Url
             Template           = $site.Template
-            Owner              = $site.OwnerEmail
+            Owner              = $GlobalAdminAccount.UserName # Passing in bogus value to bypass null owner error
             Title              = $site.Title
             TimeZoneId         = $site.TimeZoneID
         }


### PR DESCRIPTION
#### Pull Request (PR) description
SPOSite now has owner as a mandatory property. This PR allows the extraction of SPOSite without owners, but will result in an error when trying to compile the config when it's the case.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/403)
<!-- Reviewable:end -->
