### PR TITLE
O365User, O365Group: Extract more than first 100

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365Group/MSFT_O365Group.psm1
@@ -358,7 +358,7 @@ function Export-TargetResource
     $content = ''
     Test-MSCloudLogin -CloudCredential $GlobalAdminAccount `
         -Platform AzureAD
-    $groups = Get-AzureADGroup | Where-Object -FilterScript {
+    $groups = Get-AzureADGroup -All $true | Where-Object -FilterScript {
         $_.MailNickName -ne "00000000-0000-0000-0000-000000000000"
     }
 

--- a/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_O365User/MSFT_O365User.psm1
@@ -574,7 +574,7 @@ function Export-TargetResource
             $principal = $organization.Split(".")[0]
         }
     }
-    $users = Get-AzureADUser
+    $users = Get-AzureADUser -All $true
     $content = ''
     $partialContent = ""
     $i = 1


### PR DESCRIPTION
#### Pull Request (PR) description
With the current implementation, only the first hundred AD users and groups are extracted.
Added the _-All $true_ to cmdlets (**Get-AzureADGroup** and **Get-AzureADUser**) to force extraction of all the groups and users. 
The extraction process will take a longer time, but all the groups and users will be extracted.

#### This Pull Request (PR) fixes the following issues
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/409)
<!-- Reviewable:end -->
