### PR TITLE
ODSettings - Fixing issue where Set-SPOTenant was being called with Ensure

### DIFF
--- a/Modules/Office365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
+++ b/Modules/Office365DSC/DSCResources/MSFT_ODSettings/MSFT_ODSettings.psm1
@@ -268,6 +268,11 @@ function Set-TargetResource
     $CurrentParameters = $PSBoundParameters
     $CurrentParameters.Remove("GlobalAdminAccount")
 
+    if ($CurrentParameters.ContainsKey("Ensure"))
+    {
+        $CurrentParameters.Remove("Ensure")
+    }
+
     if ($CurrentParameters.ContainsKey("BlockMacSync"))
     {
         $CurrentParameters.Remove("BlockMacSync")


### PR DESCRIPTION
#### Pull Request (PR) description
The Set-TargetResource wasn't removing the Ensure parameters from the set before attempting to call into Set-SPOTenant.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/416)
<!-- Reviewable:end -->
