### PR TITLE
Added a new cmdlet Assert-O365DSCTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   * Fixed an issue with Policies without tags in their name (e.g. Global);
 * TeamsUpgradePolicy
   * Initial Release;
-* Office365Util
+* Office365DSCUtil
   * Added the new Assert-O365DSCTemplate cmdlet to assess remote templates;
 * ReverseDSC
   * Change to allow ComponentsToExtract without the 'chck' prefix;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   * Fixed an issue with Policies without tags in their name (e.g. Global);
 * TeamsUpgradePolicy
   * Initial Release;
+* Office365Util
+  * Added the new Assert-O365DSCTemplate cmdlet to assess remote templates;
 * ReverseDSC
   * Change to allow ComponentsToExtract without the 'chck' prefix;
 * Metadata

--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -1253,3 +1253,32 @@ function Remove-NullEntriesFromHashtable
 
     return $Hash
 }
+
+function Assert-O365DSCTemplate
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [System.String]
+        $Path
+    )
+    $InformationPreference = 'SilentlyContinue'
+    $WarningPreference = 'SilentlyContinue'
+
+    #region Telemetry
+    $data = [System.Collections.Generic.Dictionary[[String], [String]]]::new()
+    $data.Add("Event", "AssertTemplate")
+    Add-O365DSCTelemetryEvent -Data $data
+    #endregion
+
+    if (Test-Path -Path $Path)
+    {
+
+    }
+    else
+    {
+        $ErrorMessage = "Assert-O365DSCTemplate - Path {$Path} was not found"
+        New-Office365DSCLogEntry -Error $ErrorMessage -Message $ErrorMessage -Source $MyInvocation.MyCommand.ModuleName
+        throw $ErrorMessage
+    }
+}

--- a/Modules/Office365DSC/Office365DSC.psd1
+++ b/Modules/Office365DSC/Office365DSC.psd1
@@ -107,7 +107,8 @@
     #FunctionsToExport = @()
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-    CmdletsToExport   = 'Export-O365Configuration'
+    CmdletsToExport   = @('Export-O365Configuration',
+                          'Assert-O365DSCTemplate')
 
     # Variables to export from this module
     # VariablesToExport = @()


### PR DESCRIPTION
#### Pull Request (PR) description
Introduces a new cmdlet to assess any given tenant against a template (O365DSC config). Under the cover it dynamically extracts the configuration out of any existing .o365 or .ps1 file, dynamically compiles it and runs Test-DSCConfiguration -ReferenceConfiguration against the compiled file.

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/433)
<!-- Reviewable:end -->
