### PR TITLE
Added TemplateName parameter to the Assert-O365DSCTemplate cmdlet

### DIFF
--- a/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
+++ b/Modules/Office365DSC/Modules/Office365DSCUtil.psm1
@@ -1277,9 +1277,13 @@ function Assert-O365DSCTemplate
 {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter()]
         [System.String]
-        $TemplatePath
+        $TemplatePath,
+
+        [Parameter()]
+        [System.String]
+        $TemplateName
     )
     $InformationPreference = 'SilentlyContinue'
     $WarningPreference = 'SilentlyContinue'
@@ -1290,6 +1294,24 @@ function Assert-O365DSCTemplate
     Add-O365DSCTelemetryEvent -Data $data
     #endregion
 
+    if (([System.String]::IsNullOrEmpty($TemplatePath) -and [System.String]::IsNullOrEmpty($TemplateName)) -or
+    (-not [System.String]::IsNullOrEmpty($TemplatePath) -and -not [System.String]::IsNullOrEmpty($TemplateName)))
+    {
+        throw "You need to one of either TemplatePath or TemplateName"
+    }
+    if (-not [System.String]::IsNullOrEmpty($TemplateName))
+    {
+        try
+        {
+            $TemplatePath = Join-Path -Path $env:Temp -ChildPath "$TemplateName.o365"
+            $url = "https://office365dsc.blob.core.windows.net/office365dsc/Templates/$TemplateName.o365"
+            Invoke-WebRequest -Uri $url -OutFile $TemplatePath
+        }
+        catch
+        {
+            throw $_
+        }
+    }
     if ((Test-Path -Path $TemplatePath) -and ($TemplatePath -like '*.o365' -or $TemplatePath -like '*.ps1'))
     {
         $tokens = $null


### PR DESCRIPTION
#### Pull Request (PR) description
Using -TemplateName automatically assesses a tenant against a template hosted in the Template repo:

e.g. Assert-O365DSCTemplate -TemplateName Teams-M365Business-Baseline

Will assess against:
http://office365dsc.com/Pages/Templates/Teams-Microsoft365Business-Baseline.aspx

#### This Pull Request (PR) fixes the following issues
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/office365dsc/438)
<!-- Reviewable:end -->
